### PR TITLE
Store email contents in catalog SearchableText

### DIFF
--- a/mailtoplone/base/adapter.py
+++ b/mailtoplone/base/adapter.py
@@ -18,7 +18,6 @@
 #  along with this program; if not, write to the Free Software
 #  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-
 __author__    = """Hans-Peter Locher<hans-peter.locher@inquant.de>"""
 __docformat__ = 'plaintext'
 __revision__  = "$Revision: 36831 $"
@@ -41,7 +40,6 @@ from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Acquisition import aq_base
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
-
 
 from mailtoplone.base.interfaces import IMailDropBox, IMailIndexer
 from mailtoplone.base.events import MailDroppedEvent
@@ -112,10 +110,7 @@ class MailIndexer(object):
 
         request = getRequest()
 
-        try:
-            view = getMultiAdapter((self.context, request,), name=u"view")
-        except:
-            import pdb; pdb.set_trace()
+        view = getMultiAdapter((self.context, request,), name=u"view")
 
         headers =  view.headers()
         indexed = [x.get('contents', '')[0] for x in headers]

--- a/mailtoplone/base/browser/configure.zcml
+++ b/mailtoplone/base/browser/configure.zcml
@@ -10,7 +10,7 @@
     <!-- publishing the adapter MailDropBox method drop for usage with xmlrpc -->
     <browser:page
       for="..interfaces.IMailDropBoxMarker"
-      name="xmlrpcview"
+      name="drop"
       class=".xmlrpcview.XMLRPCView"
       attribute="drop"
       permission="zope.Public"

--- a/mailtoplone/base/browser/configure.zcml
+++ b/mailtoplone/base/browser/configure.zcml
@@ -10,7 +10,7 @@
     <!-- publishing the adapter MailDropBox method drop for usage with xmlrpc -->
     <browser:page
       for="..interfaces.IMailDropBoxMarker"
-      name="drop"
+      name="xmlrpcview"
       class=".xmlrpcview.XMLRPCView"
       permission="zope.Public"
       allowed_interface=".xmlrpcview.IXMLRPCView"

--- a/mailtoplone/base/configure.zcml
+++ b/mailtoplone/base/configure.zcml
@@ -44,6 +44,12 @@
         factory=".adapter.MailDropBox"
         />
 
+    <adapter
+        provides=".interfaces.IMailIndexer"
+        for=".interfaces.IEmail"
+        factory=".adapter.MailIndexer"
+        />
+
     <!-- Custom Trigger for Content Rules -->
     <interface 
       interface=".interfaces.IMailDroppedEvent" 

--- a/mailtoplone/base/content/email.py
+++ b/mailtoplone/base/content/email.py
@@ -1,6 +1,7 @@
 """Definition of the Email content type
 """
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 
 from zope.component import getUtility, getAdapter, getMultiAdapter
 from zope.interface import implements, directlyProvides
@@ -59,7 +60,7 @@ class Email(file.ATFile):
         if mail_body.get('content_type') == 'text/html':
             portal_transforms = getToolByName(self, 'portal_transforms')
             data = portal_transforms.convertTo('text/plain', mail_text, mimetype='text/html')
-            mail_text = data.getData()
+            mail_text = safe_unicode(data.getData())
 
         indexed.append(mail_text)
 

--- a/mailtoplone/base/content/email.py
+++ b/mailtoplone/base/content/email.py
@@ -1,7 +1,9 @@
 """Definition of the Email content type
 """
 
+from zope.component import getUtility, getAdapter, getMultiAdapter
 from zope.interface import implements, directlyProvides
+from zope.globalrequest import getRequest
 
 from Products.Archetypes import atapi
 from Products.ATContentTypes.content import file
@@ -12,6 +14,9 @@ from Products.ATContentTypes.content.schemata import finalizeATCTSchema
 from mailtoplone.base import baseMessageFactory as _
 from mailtoplone.base.interfaces import IEmail
 from mailtoplone.base.config import PROJECTNAME
+
+
+
 
 EmailSchema = file.ATFileSchema.copy() + atapi.Schema((
 
@@ -34,8 +39,17 @@ class Email(file.ATFile):
     portal_type = "Email"
     _at_rename_after_creation = True
     schema = EmailSchema
+    schema['file'].index_method = 'mail_indexer'
 
     title = atapi.ATFieldProperty('title')
     description = atapi.ATFieldProperty('description')
-    
+
+    def mail_indexer(self):
+        request = getRequest()
+
+        view = getMultiAdapter((self, request,), name=u"view")
+        mail_body = view.body()
+
+        return mail_body.get('text', '')
+
 atapi.registerType(Email, PROJECTNAME)

--- a/mailtoplone/base/interfaces.py
+++ b/mailtoplone/base/interfaces.py
@@ -110,4 +110,11 @@ class IMailDroppedEvent(component.interfaces.IObjectEvent):
     object = interface.Attribute("The mail object of the event.")
     context = interface.Attribute("The context of the event.")
 
+
+class IMailIndexer(component.interfaces.IObjectEvent):
+    def index(mail):
+        """ indexes mail body text and mail headers for
+            use in catalog SearcableText
+        """
+
 # vim: set ft=python ts=4 sw=4 expandtab :

--- a/mailtoplone/base/scripts/fetchemail
+++ b/mailtoplone/base/scripts/fetchemail
@@ -32,6 +32,9 @@ def main():
     option_parser.add_option( "-s", "--silent", dest="silent",
             default=0,
             help="if set to 1, all print statements muted" )
+    option_parser.add_option( "-m", "--max_retries", dest="max_retries",
+            default=1000,
+            help="max number of retries" )
 
     (options, args) = option_parser.parse_args()
 
@@ -59,26 +62,46 @@ def main():
     except Exception as e:
         silent = False
 
-    mailbox = imaplib.IMAP4_SSL(imap_server, imap_port)
-    mailbox.login(email, password)
-    mailbox.select()
+    try:
+        max_retries = int(options.max_retries)
+    except Exception as e:
+        max_retries = 1000
 
-    typ, data = mailbox.search(None, 'UnSeen')
-    mail_nums = data[0].split()
-    if not silent:
-        print 'Got {0} emails'.format(len(mail_nums))
+    n_retries = 0
 
-    for idx, num in enumerate(mail_nums):
+    # Make sure to reconnect in case if it's not possible.
+    while n_retries < max_retries:
+        mailbox = imaplib.IMAP4_SSL(imap_server, imap_port)
+        mailbox.login(email, password)
+
+        try:
+            mailbox.select()
+
+            typ, data = mailbox.search(None, 'UnSeen')
+            mail_nums = data[0].split()
+            if not silent:
+                print 'Got {0} emails'.format(len(mail_nums))
+
+            for idx, num in enumerate(mail_nums):
+                if not silent:
+                    print 'Processing mail {0}/{1}'.format(idx+1, len(mail_nums))
+                typ, data = mailbox.fetch(num, '(RFC822)')  # Mail is marked as read when fetched
+                mail = data[0][1]
+                server = xmlrpclib.Server(url)
+                server.drop(mail)
+
+        except mailbox.abort as e:
+            n_retries += 1
+            continue
+
+        mailbox.close()
+        mailbox.logout()
+        break
+
+    # If max_retries exceeds the limits set, give up and write to the logs.
+    else:
         if not silent:
-            print 'Processing mail {0}/{1}'.format(idx+1, len(mail_nums))
-        typ, data = mailbox.fetch(num, '(RFC822)')  # Mail is marked as read when fetched
-        mail = data[0][1]
-        server = xmlrpclib.Server(url)
-        server.drop(mail)
-
-
-    mailbox.close()
-    mailbox.logout()
+            print "Problems connecting to the IMAP server. Gave up after {0} retries.".format(max_retries)
 
 if __name__ == "__main__":
     main()

--- a/mailtoplone/base/scripts/fetchemail
+++ b/mailtoplone/base/scripts/fetchemail
@@ -29,6 +29,9 @@ def main():
     option_parser.add_option( "-p", "--password", dest="password",
             default=None,
             help="password for imap server" )
+    option_parser.add_option( "-s", "--silent", dest="silent",
+            default=0,
+            help="if set to 1, all print statements muted" )
 
     (options, args) = option_parser.parse_args()
 
@@ -51,16 +54,23 @@ def main():
     email = options.email
     password = options.password
 
+    try:
+        silent = bool(int(options.silent))
+    except Exception as e:
+        silent = False
+
     mailbox = imaplib.IMAP4_SSL(imap_server, imap_port)
     mailbox.login(email, password)
     mailbox.select()
 
     typ, data = mailbox.search(None, 'UnSeen')
     mail_nums = data[0].split()
-    print 'Got {0} emails'.format(len(mail_nums))
+    if not silent:
+        print 'Got {0} emails'.format(len(mail_nums))
 
     for idx, num in enumerate(mail_nums):
-        print 'Processing mail {0}/{1}'.format(idx+1, len(mail_nums))
+        if not silent:
+            print 'Processing mail {0}/{1}'.format(idx+1, len(mail_nums))
         typ, data = mailbox.fetch(num, '(RFC822)')  # Mail is marked as read when fetched
         mail = data[0][1]
         server = xmlrpclib.Server(url)

--- a/mailtoplone/base/tests/test_mailindexer.py
+++ b/mailtoplone/base/tests/test_mailindexer.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# File: test_emailview.py
+#
+# Copyright (c) InQuant GmbH
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+import unittest
+from zope.globalrequest import setRequest
+from zope.interface.interface import InterfaceClass
+from zope.publisher.browser import TestRequest
+from mailtoplone.base.adapter import MailIndexer
+from mailtoplone.base.content.email import EmailSchema
+from mailtoplone.base.interfaces import IMailIndexer
+
+from mailtoplone.base.tests.base import MailToPloneBaseTestCase
+
+
+class TestMailIndexer(MailToPloneBaseTestCase):
+
+    def afterSetUp(self):
+        self.setRoles(('Manager',))
+        self.portal.invokeFactory('Email', 'm1')
+
+    def test_file_schema(self):
+        """ The mail_indexer function is set in AT schema as
+            index_method on file field
+        """
+        schema = EmailSchema
+        self.assertEqual(schema['file'].index_method, 'mail_indexer')
+
+    def test_mail_indexer(self):
+        """ Check if the mail_indexer function is present on
+        an Email content type
+        """
+        text = self.portal['m1'].mail_indexer()
+        self.assertEqual(text, '')  # No email is stored, so output is empty
+
+    def test_adapter(self):
+        """ Basic tests on the indexer adapter """
+        adapter = IMailIndexer(self.portal['m1'])
+
+        self.assertEqual(type(IMailIndexer), InterfaceClass)
+        self.assertEqual(type(adapter), MailIndexer)
+        self.assertTrue(hasattr(adapter, 'indexer'))  # Adapter has indexer function
+
+        text = IMailIndexer(self.portal['m1']).index()
+        self.assertEqual(text, '')  # No email is stored, so output is empty
+
+
+def test_suite():
+    setRequest(TestRequest())  # Set fake request on zope global request
+
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(TestMailIndexer))
+    return suite
+
+# vim: set ft=python ts=4 sw=4 expandtab :
+


### PR DESCRIPTION
Currently the raw email in the Email content type is stored as SearchableText in the catalog. The raw email contains a lot of stuff we don't want indexed. 

I've changed the Email content type, an adapter is called to return a string which is used as SearchableText by the catalog. The adapter used the email browser view to the email body and headers, both are returned as searchable text. I've also added tests for my changes.
